### PR TITLE
Updated OAS. Include cognito_user_pools

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,29 +29,54 @@ components:
     IndicatorsRequest:
       type: object
       required:
-        - id
+        - projectId
+        - name
+        - description
+        - projectImpacts
+        - outcomesDesired
       properties:
-        id:
+        projectId:
           type: string
+        name:
+          type: string
+        description:
+          type: string
+        projectImpacts:
+          type: array
+          items:
+            type: string
+        outcomesDesired:
+          type: array
+          items:
+            type: string
     Indicators:
       type: object
       properties:
-        word:
+        projectId:
           type: string
-        vector:
+        indicators:
           type: array
           items:
-            type: integer
+            type: object
+            properties:
+              indicatorID:
+                type: number
+              alignedStrength:
+                type: number
     IndicatorsResponse:
       type: object
       properties:
-        success:
-          type: boolean
         data:
           $ref: '#/components/schemas/Indicators'
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
+    isgoodUserPool:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: cognito_user_pools
+      x-amazon-apigateway-authorizer:
+        type: cognito_user_pools
+        providerARNs:
+          - arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}
 security:
-  - bearerAuth: []
+  - isgoodUserPool: []


### PR DESCRIPTION
Updated OAS based on the detail provided in:
https://docs.isgood.ai/api-and-data-specs/open-api#initial-api-between-webapp-and-ds-functions

Also added `cognito_user_pools` config for authenticating against a user pool as detailed in:
https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enable-cognito-user-pool.html

The placeholders on line 80 need to be replaced with actual values, as I understand it, from the Terraform output for the User Pool. Disclaimer: there may be a better way of doing this, but hopefully a good starter for ten at least.